### PR TITLE
Add python-lxml libselinux-python

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-amq_broker_dependencies: wget, libaio, unzip
+amq_broker_dependencies: wget, libaio, unzip, libselinux-python, python-lxml


### PR DESCRIPTION
These were required to deploy a 3 node cluster.  Unless these were manually stalled the playbook failed.