### PR TITLE
Mixture of additions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,7 +62,7 @@ amq_broker_shared_store_dir: "{{ lookup('env','AMQ_SHARED_DIRECTORY') | default(
 
 # Whether to install (manage) Java JVM and which one to install
 amq_broker_jvm_install: true
-amq_broker_jvm: "{{ lookup('env','JAVA_TYPE') | default('java-1.8.0-openjdk-devel') }}"   # java-11-openjdk-devel
+amq_broker_jvm: "{{ lookup('env','JAVA_TYPE') | default('java-1.8.0-openjdk') }}"   # java-11-openjdk-devel
 
 # Journal type for the broker instance
 amq_broker_instance_journal_type: nio

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -88,13 +88,6 @@ amq_broker_default_admin_port: 8161
 amq_broker_default_cluster_port: 9876
 amq_broker_default_cluster_netty_connector_port: 61617
 
-# TODO not used much
-#amq_broker_main_port
-#amq_broker_amqp_port
-#amq_broker_mqtt_port
-#amq_broker_core_port
-#amq_broker_stomp_port
-#amq_broker_jmx_port
 
 # Jolokia stuff
 amq_broker_jolokia_allow_origin: "*://0.0.0.0*"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,9 +60,9 @@ amq_broker_db_driver_url: "{{ lookup('env','AMQ_BROKER_DB_DRIVER_DOWNLOAD_URL') 
 # Shared store location on given node
 amq_broker_shared_store_dir: "{{ lookup('env','AMQ_SHARED_DIRECTORY') | default(None) }}"
 
-# Whether to install Java JVM and which one to install
+# Whether to install (manage) Java JVM and which one to install
 amq_broker_jvm_install: true
-amq_broker_jvm: java-1.8.0-openjdk-devel
+amq_broker_jvm: "{{ lookup('env','JAVA_TYPE') | default('java-1.8.0-openjdk-devel') }}"   # java-11-openjdk-devel
 
 # Journal type for the broker instance
 amq_broker_instance_journal_type: nio

--- a/tasks/create_amq_broker_instance.yml
+++ b/tasks/create_amq_broker_instance.yml
@@ -12,25 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- name: Ensure Java VM is present {{ amq_broker_jvm }}
-  when:
-    - amq_broker_jvm is defined and amq_broker_jvm_install is defined and amq_broker_jvm_install == true
-  package: name={{ amq_broker_jvm }} state=present
-
-- name: Get appropriate JVM version path
-  shell: 'alternatives --display java |grep -E "{{ amq_broker_jvm | regex_replace("-devel") | regex_replace("java-") | quote }}.*priority" | cut -d" " -f 1'
-  register: java_alternatives_cmd
-
-- debug: msg="JVM path to set= {{ java_alternatives_cmd.stdout }}"
-
-- name: Get JVM executable
-  command: "which java"
-  register: java_bin
-
-- name: Set correct JVM version
-  when: java_alternatives_cmd.stdout is defined and java_alternatives_cmd != ""
-  command: alternatives --set java "{{ java_alternatives_cmd.stdout }}"
-
 - name: Remove broker instance directory
   when: amq_broker_instance_create_force is defined and amq_broker_instance_create_force == true
   file: path="{{ amq_broker_install_dest }}/{{ amq_broker_instance_dir }}" state=absent

--- a/tasks/get_amq_broker_distribution.yml
+++ b/tasks/get_amq_broker_distribution.yml
@@ -66,11 +66,16 @@
     group: "{{ amq_broker_user | default(amq_broker_default_user) }}"
     force: true
 
-- name: Ensure correct ownership
+- name: Ensure correct ownership of broker destination
   tags:
     - broker
     - ownership
-  shell: chown -R "{{ amq_broker_user | default(amq_broker_default_user) }}":"{{ amq_broker_user | default(amq_broker_default_user) }}" {{ amq_broker_install_dest }}
+  file:
+    owner: "{{ amq_broker_user | default(amq_broker_default_user) }}"
+    group: "{{ amq_broker_user | default(amq_broker_default_user) }}"
+    path: "{{ amq_broker_install_dest }}"
+    recurse: yes
+    force: yes
 
 - name: Download JDBC DB connection driver
   when:

--- a/tasks/jvm_manage.yml
+++ b/tasks/jvm_manage.yml
@@ -1,0 +1,31 @@
+# Copyright 2017 Red Hat, Inc. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- name: Ensure Java VM package is present {{ amq_broker_jvm }}
+  when:
+    - amq_broker_jvm is defined and amq_broker_jvm_install is defined and amq_broker_jvm_install == true
+  package: name={{ amq_broker_jvm }} state=present
+
+- name: Get appropriate JVM version path
+  shell: 'alternatives --display java |grep -E "{{ amq_broker_jvm | regex_replace("-devel") | regex_replace("java-") | quote }}.*priority" | head -n 1| cut -d" " -f 1'
+  register: java_alternatives_cmd
+
+- name: "Set up java alternative to correct one {{ java_alternatives_cmd.stdout }}"
+  alternatives:
+    name: "java"
+    path: "{{ java_alternatives_cmd.stdout }}"
+
+- name: Get JVM executable
+  command: "which java"
+  register: java_bin

--- a/tasks/jvm_manage.yml
+++ b/tasks/jvm_manage.yml
@@ -15,15 +15,19 @@
 - name: Ensure Java VM package is present {{ amq_broker_jvm }}
   when:
     - amq_broker_jvm is defined and amq_broker_jvm_install is defined and amq_broker_jvm_install == true
-  package: name={{ amq_broker_jvm }} state=present
+  package: name={{ item }} state=present
+  with_items:
+    - "{{ amq_broker_jvm }}"
+    - "{{ amq_broker_jvm }}-devel"
 
 - name: Get appropriate JVM version path
   shell: 'alternatives --display java |grep -E "{{ amq_broker_jvm | regex_replace("-devel") | regex_replace("java-") | quote }}.*priority" | head -n 1| cut -d" " -f 1'
   register: java_alternatives_cmd
 
-- name: "Set up java alternative to correct one {{ java_alternatives_cmd.stdout }}"
+- name: Set up java alternative to currently needed {{ java_alternatives_cmd.stdout }}
   alternatives:
     name: "java"
+    link: "/usr/bin/java"
     path: "{{ java_alternatives_cmd.stdout }}"
 
 - name: Get JVM executable

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,13 @@
   include: get_amq_broker_distribution.yml
   when: amq_broker_skip_install is defined and amq_broker_skip_install == false
 
+- name: Set up JVM
+  tags:
+    - jvm
+    - install
+  include: jvm_manage.yml
+  when: amq_broker_jvm_install == true
+
 - name: Create JBoss AMQ 7 Broker default instance
   tags:
     - broker

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-amq_broker_dependencies: wget, libaio, unzip, libselinux-python, python-lxml, tar
+amq_broker_dependencies: wget, libaio, unzip, tar


### PR DESCRIPTION
- Remove of obsolete packages
- Use file module instead of chown as shell command
- Control JVM installation/setting up via alternatives module (remove shell commands to minimum)
- Provide JDK package name, instead of "-devel" package name, which is ugly